### PR TITLE
Modernize Pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,13 +39,13 @@
 
     <!-- Build Settings -->
     <build>
-        <sourceDirectory>${basedir}/src/</sourceDirectory>
+        <sourceDirectory>${project.basedir}/src/</sourceDirectory>
 
         <!-- Resources -->
         <resources>
             <resource>
                 <targetPath>.</targetPath>
-                <directory>${basedir}/src/resources/</directory>
+                <directory>${project.basedir}/src/resources/</directory>
             </resource>
         </resources>
 


### PR DESCRIPTION
{basedir} is now deprecated in the newer versions of Maven, the modern version is {project.basedir}
